### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,5 +36,5 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -VV -C ${{env.BUILD_TYPE}}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install boost
-      run: sudo apt-get install -y libboost-all-dev
+      run: sudo apt-get install -y libboost-program-options-dev
   
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
+    
+    - name: Install boost
+      run: sudo apt-get install -y libboost-dev-all
+  
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,11 +38,11 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
         ulimit -c unlimited
-        sudo ctest -VV -C ${{env.BUILD_TYPE}}
-        sudo chmod -R +rwx /cores/*
+        ./stm_tests
+        ls
         
-    - uses: actions/upload-artifact@master # capture all crashes as build artifacts
-      with:
-        name: crashes
-        path: /cores
+    # - uses: actions/upload-artifact@master # capture all crashes as build artifacts
+    #   with:
+    #     name: crashes
+    #     path: /cores
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,5 +36,13 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -VV -C ${{env.BUILD_TYPE}}
+      run: |
+        ulimit -c unlimited
+        sudo ctest -VV -C ${{env.BUILD_TYPE}}
+        sudo chmod -R +rwx /cores/*
+        
+    - uses: actions/upload-artifact@master # capture all crashes as build artifacts
+      with:
+        name: crashes
+        path: /cores
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,7 +38,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
         ulimit -c unlimited
-        ./stm_tests
+        sudo ctest -VV -C ${{env.BUILD_TYPE}}
         ls
         
     # - uses: actions/upload-artifact@master # capture all crashes as build artifacts

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install boost
-      run: sudo apt-get install -y libboost-dev-all
+      run: sudo apt-get install -y libboost-all-dev
   
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/stm.cpp
+++ b/stm.cpp
@@ -7,15 +7,19 @@
 #include <set>
 #include <algorithm>
 #include <signal.h>
+#include <string.h>
 
 bool TxThread::inReadSet(uint64_t addr){
     return find(read_set.begin(), read_set.end(), (intptr_t*) addr) != read_set.end();
 }
 
 
-void raceHandler(int signum, siginfo_t * sig_info, void* context){
+void sigHandler(int signum, siginfo_t * sig_info, void* context){
     uint64_t faulted_addr = (uint64_t) sig_info->si_addr;
-    psignal(signum, "Possible UAF");
+    if(write(1, "Possible UAF\n", strlen("Possible UAF\n")) < 0){
+        cout << "failed to write" << endl;
+        exit(1);
+    }
     if(_my_thread.inReadSet(faulted_addr)){
         _my_thread.txAbort();
     }
@@ -23,7 +27,7 @@ void raceHandler(int signum, siginfo_t * sig_info, void* context){
 
 void registerSignalHandlers(){
     struct sigaction sig_handler;
-    sig_handler.sa_sigaction = raceHandler;
+    sig_handler.sa_sigaction = sigHandler;
     sigemptyset(&sig_handler.sa_mask);
     sig_handler.sa_flags = SA_SIGINFO;
     sigaction(SIGSEGV, &sig_handler, NULL);

--- a/stm.cpp
+++ b/stm.cpp
@@ -29,7 +29,7 @@ void registerSignalHandlers(){
     struct sigaction sig_handler;
     sig_handler.sa_sigaction = sigHandler;
     sigemptyset(&sig_handler.sa_mask);
-    sig_handler.sa_flags = SA_SIGINFO;
+    sig_handler.sa_flags = SA_SIGINFO | SA_NODEFER;
     sigaction(SIGSEGV, &sig_handler, NULL);
 }
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -328,7 +328,7 @@ void run_tests()
 }
 
 int main(){
-    const int TRIALS = 50;
+    const int TRIALS = 100;
     for(int i = 0; i < TRIALS; i++){
         cout << "------------ Starting trial " << i << " -----------" << endl;
         run_tests();


### PR DESCRIPTION
Experienced segfaults on GitHub Action hardware, not exactly sure why since there is a segfault handler. 

Added no defer flag to sigaction flags in case somehow there are more SIGSEGV than threads (cores?). Not sure how this would ever arise though. Seems to solve the issue on the GitHub actions server but requires further inquiry.